### PR TITLE
Use A1 instead of Magenta for Austria

### DIFF
--- a/speedtest.sh
+++ b/speedtest.sh
@@ -330,7 +330,7 @@ print_speedtest_europe() {
 	speed_test '21378' 'Spain, Madrid (MasMovil)        ' 'http://speedtest-mad.masmovil.com'
 	speed_test '395' 'Italy, Rome (Unidata)           ' 'http://speedtest2.unidata.it'
 	speed_test '20411' 'Czechia, Prague (Dial Telecom)  ' 'http://speedtest-praha.dialtelecom.cz'
-	speed_test '5351' 'Austria, Vienna (Magenta)       ' 'http://speedtest-2.upc.at'
+	speed_test '12390' 'Austria, Vienna (A1)            ' 'http://speedtest.a1.net'
 	speed_test '4166' 'Poland, Warsaw (Orange)         ' 'http://war-o2.speedtest.orange.pl'
 	speed_test '30813' 'Ukraine, Kyiv (KyivStar)        ' 'http://srv01-okl-kv.kyivstar.ua'
 	speed_test '5834' 'Latvia, Riga (Bite)             ' 'http://speedtest2.bite.lv'


### PR DESCRIPTION
The Magenta network appears not be a good representation for Austria in my opinion. Magenta—a subsidiary of the Deutsche Telekom AG—routes nearly all their traffic through Frankfurt, Germany (even some of the inner-Austrian traffic) and thus consistently shows higher than usual latencies towards Vienna. Austria has 3 major ISPs (A1, Drei & Magenta) and lots of smaller ones. All of them appear to do a much better job at routing traffic. Why not use any of them instead?

I would suggest using [A1](https://www.a1.net/) instead for the simple reason that it is the largest ISP in Austria.

I've already attached a pull request to swap the speedtest servers to the A1 ones if you would like to accept my suggestion.